### PR TITLE
Add default value for az_devops_deployment_group_name

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,4 +7,5 @@ az_devops_work_folder: "/home/{{ az_devops_agent_user }}/agent/_work"
 az_devops_agent_pool_name: "Default"
 az_devops_agent_role: "build"
 az_devops_deployment_group_tags: null
+az_devops_deployment_group_name: "Default"
 az_devops_agent_replace_existing: false


### PR DESCRIPTION
This variable didn't have a default, even though it could easily have
had one.