### PR TITLE
Let project name be null as default, as it is not needed for build agent

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,3 +9,4 @@ az_devops_agent_role: "build"
 az_devops_deployment_group_tags: null
 az_devops_deployment_group_name: "Default"
 az_devops_agent_replace_existing: false
+az_devops_project_name: null


### PR DESCRIPTION
Partly a fix of #7 