### PR TITLE
use a non default pool name for the agent to join

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -71,7 +71,7 @@
       - "--token '{{ az_devops_accesstoken }}'"
       - "--runasservice"
     build_agent_cmd_args:
-      - "--pool"
+      - "--pool '{{az_devops_agent_pool_name }}'"
       - "--agent '{{ az_devops_agent_name }}'"
     deployment_agent_cmd_args:
       - "--deploymentgroup"


### PR DESCRIPTION
According to the [documentation](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/v2-linux?view=azure-devops#pool-and-agent-names), the pool name for the agent to join can be set with the `--pool` argument.