### PR TITLE
Centos

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -9,7 +9,7 @@ az_devops_agent_role: "build"
 az_devops_agent_replace_existing: false
 az_devops_reconfigure_agent: false
 az_devops_project_name: null
-az_devops_agent_package_url: "https://vstsagentpackage.azureedge.net/agent/{{ az_devops_agent_version }}/vsts-agent-linux-x64-{{ az_devops_agent_version }}.tar.gz"
+az_devops_agent_package_url: "https://vstsagentpackage.azureedge.net/agent/{{ az_devops_agent_version }}/vsts-agent-{{ 'rhel.6-x64' if (ansible_distribution in ['RedHat','CentOS']) else 'linux-x64' }}-{{ az_devops_agent_version }}.tar.gz"
 az_devops_environment_name: null
 az_devops_deployment_group_name: null
 az_devops_deployment_group_tags: null

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,6 +14,9 @@ galaxy_info:
         - trusty
         - xenial
         - bionic
+    - name: EL
+      versions:
+        - 7
 
   galaxy_tags:
     - azure


### PR DESCRIPTION
Add support for a Centos 7 based [linux self hosted agent](https://docs.microsoft.com/en-us/azure/devops/pipelines/agents/v2-linux?view=azure-devops).
Successfully tested with the [Centos 7 Vagrant box](https://app.vagrantup.com/centos/boxes/7) setting the environment variable [`DOTNET_SYSTEM_GLOBALIZATION_INVARIANT`](https://docs.microsoft.com/en-us/dotnet/core/run-time-config/globalization) to `true` because of the default OS language not set to `en_US.UTF-8` but `fr_FR.UTF-8` in my case.