### PR TITLE
Make role work on multiple platforms

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,6 +57,10 @@ Available variables are listed below, along with default values (see `defaults/m
 
   Name of the user used to run and configure the service.
 
+- **az_devops_agent_group**
+
+  Default group of the user used to run and configure the service.
+
 - **az_devops_agent_name**
 
   Name of the agent shown in Azure DevOps (defaults to the name of the host.).

--- a/README.md
+++ b/README.md
@@ -8,6 +8,9 @@ See [this blog post](https://medium.com/gsoft-tech/easily-configuring-an-azure-d
 
 [See prerequisites](https://github.com/Microsoft/azure-pipelines-agent/blob/master/docs/start/envlinux.md)
 
+Installing on MacOS can be problematic when trying to use an admin user for connecting and another user for running the service.
+pipelining = True can help, especially if you run into issues where the devops agent user cannot access the temporary files ansible is creating.
+
 ## Role Variables
 
 Available variables are listed below, along with default values (see `defaults/main.yml`):

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -2,8 +2,8 @@ az_devops_agent_version: 2.168.2
 az_devops_agent_user: "az_devops_agent"
 az_devops_agent_name: "{{ ansible_hostname }}"
 az_devops_server_url: "https://dev.azure.com/{{ az_devops_accountname }}/"
-az_devops_agent_folder: "/home/{{ az_devops_agent_user }}/agent/"
-az_devops_work_folder: "/home/{{ az_devops_agent_user }}/agent/_work"
+az_devops_agent_folder: "{{ az_devops_default_agent_folder }}"
+az_devops_work_folder: "{{ az_devops_default_work_folder }}"
 az_devops_agent_pool_name: "Default"
 az_devops_agent_role: "build"
 az_devops_agent_replace_existing: false

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -4,12 +4,13 @@ az_devops_agent_name: "{{ ansible_hostname }}"
 az_devops_server_url: "https://dev.azure.com/{{ az_devops_accountname }}/"
 az_devops_agent_folder: "{{ az_devops_default_agent_folder }}"
 az_devops_work_folder: "{{ az_devops_default_work_folder }}"
+az_devops_agent_group: "{{ az_devops_default_agent_group }}"
 az_devops_agent_pool_name: "Default"
 az_devops_agent_role: "build"
 az_devops_agent_replace_existing: false
 az_devops_reconfigure_agent: false
 az_devops_project_name: null
-az_devops_agent_package_url: "https://vstsagentpackage.azureedge.net/agent/{{ az_devops_agent_version }}/vsts-agent-{{ 'rhel.6-x64' if (ansible_distribution in ['RedHat','CentOS']) else 'linux-x64' }}-{{ az_devops_agent_version }}.tar.gz"
+az_devops_agent_package_url: "{{ az_devops_default_agent_package_url }}"
 az_devops_environment_name: null
 az_devops_deployment_group_name: null
 az_devops_deployment_group_tags: null

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,6 +17,17 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+    - name: Debian
+      versions:
+        - stretch
+        - buster
+    - name: Windows
+      versions:
+        - 2016
+        - 2019
+    - name: MacOSX
+      versions:
+        - 10.15
 
   galaxy_tags:
     - azure

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -11,9 +11,9 @@ galaxy_info:
   platforms:
     - name: Ubuntu
       versions:
-        - trusty
         - xenial
         - bionic
+        - focal
     - name: EL
       versions:
         - 7

--- a/tasks/Darwin.yml
+++ b/tasks/Darwin.yml
@@ -1,0 +1,190 @@
+- name: Add an agent user
+  user:
+    name: "{{ az_devops_agent_user }}"
+    comment: "Azure DevOps Agent"
+    shell: /bin/zsh
+    group: admin
+  become: true
+
+- name: Create directories
+  file:
+    state: directory
+    path: "{{ item }}"
+    owner: "{{ az_devops_agent_user }}"
+    group: "{{ az_devops_agent_group }}"
+    mode: 0755
+  loop:
+    - "{{ az_devops_launchagent_folder }}"
+    - "{{ az_devops_agent_folder }}"
+    - "{{ az_devops_work_folder }}"
+  register: agent_directory
+  become: true
+
+# Using get_url and shell to unarchive the agent as the unarchive module requires homebrew and
+# even then doesn't use the provided gnu tar.
+# Makes using ansible on macos a questionable endeavor (but some of us are left with that)...
+- name: Download agent
+  get_url:
+    url: "{{ az_devops_agent_package_url }}"
+    dest: "{{ az_devops_default_agent_local_package }}"
+    owner: "{{ az_devops_agent_user }}"
+    group: "{{ az_devops_agent_group }}"
+    mode: '0440'
+  register: agent_download
+  become: true
+
+- name: Unarchive agent
+  shell: "cd {{ az_devops_agent_folder }} && tar -zxf {{ az_devops_default_agent_local_package }}"
+  become: true
+  become_user: "{{ az_devops_agent_user }}"
+  when: agent_download.changed or agent_directory.changed
+
+- name: Check if svc.sh exists
+  stat:
+    path: "{{ '/'.join((az_devops_agent_folder, 'svc.sh')) }}"
+  register: svc_sh
+  become: true
+  changed_when: false
+  check_mode: no
+
+- name: Check service status
+  command: ./svc.sh status
+  become: true
+  become_user: "{{ az_devops_agent_user }}"
+  args:
+    chdir: "{{ az_devops_agent_folder }}"
+  register: svc_status
+  changed_when: false
+  check_mode: no
+  when: svc_sh.stat.exists
+
+- name: Set agent config facts
+  set_fact:
+    agent_cmd_args:
+      - "./config.sh"
+      - "--unattended"
+      - "--acceptteeeula"
+      - "--url '{{ az_devops_server_url }}'"
+      - "--work _work"
+      - "--auth PAT"
+      - "--token '{{ az_devops_accesstoken }}'"
+      - "--runasservice"
+    build_agent_cmd_args:
+      - "--pool '{{ az_devops_agent_pool_name }}'"
+      - "--agent '{{ az_devops_agent_name }}'"
+    deployment_agent_cmd_args:
+      - "--deploymentgroup"
+      - "--deploymentgroupname '{{ az_devops_deployment_group_name }}'"
+      - "--projectname '{{ az_devops_project_name }}'"
+    resource_agent_cmd_args:
+      - "--environment"
+      - "--environmentname '{{ az_devops_environment_name }}'"
+      - "--agent '{{ az_devops_agent_name }}'"
+      - "--projectname '{{ az_devops_project_name }}'"
+    service_is_installed: "{{ svc_status.stdout is defined and svc_status.stdout is not regex('not installed') }}"
+    service_is_running: "{{ svc_status.stdout is defined and svc_status.stdout is regex('active \\(running\\)') }}"
+    reconfigure_or_replace: "{{ az_devops_reconfigure_agent or az_devops_agent_replace_existing }}"
+
+- name: Add deployment group tags
+  set_fact:
+    deployment_agent_cmd_args: "{{ deployment_agent_cmd_args }} + ['--addDeploymentGroupTags', '--deploymentGroupTags \\'{{ az_devops_deployment_group_tags }}\\'']"
+  when:
+    - az_devops_deployment_group_tags is defined
+
+- name: Set proxy
+  set_fact:
+    agent_cmd_args: "{{ agent_cmd_args }} + ['--proxyurl \\'{{ az_devops_proxy_url }}\\'', '--proxyusername \\'{{ az_devops_proxy_username }}\\'', '--proxypassword \\'{{ az_devops_proxy_password }}\\'']"
+  when: 
+    - az_devops_proxy_url is defined
+
+- name: Uninstall agent service
+  command: ./svc.sh uninstall
+  become: true
+  args:
+    chdir: "{{ az_devops_agent_folder }}"
+    removes: "{{ az_devops_agent_folder }}/runsvc.sh"
+  when:
+    - service_is_installed
+    - reconfigure_or_replace
+
+- name: Unconfigure agent
+  command: "./config.sh remove --auth PAT --token {{ az_devops_accesstoken }}"
+  args:
+    chdir: "{{ az_devops_agent_folder }}"
+    removes: "{{ az_devops_agent_folder }}/.agent"
+  become: true
+  become_user: "{{ az_devops_agent_user }}"
+  when:
+    - service_is_installed
+    - reconfigure_or_replace
+
+- name: Add '--replace' configuration argument
+  set_fact:
+    build_agent_cmd_args: "{{ build_agent_cmd_args }} + ['--replace']"
+    deployment_agent_cmd_args: "{{ build_agent_cmd_args }} + ['--replace']"
+    resource_agent_cmd_args: "{{ resource_agent_cmd_args }} + ['--replace']"
+  when:
+    - az_devops_agent_replace_existing
+
+- name: Configure agent as a build server
+  command: "{{ (agent_cmd_args + build_agent_cmd_args) | join(' ') }}"
+  args:
+    chdir: "{{ az_devops_agent_folder }}"
+    creates: "{{ az_devops_agent_folder }}/.agent"
+  become: true
+  become_user: "{{ az_devops_agent_user }}"
+  when:
+    - az_devops_agent_role == 'build'
+    - (not service_is_installed) or reconfigure_or_replace
+
+- name: Configure agent as a deployment server
+  command: "{{ (agent_cmd_args + deployment_agent_cmd_args) | join(' ') }}"
+  args:
+    chdir: "{{ az_devops_agent_folder }}"
+    creates: "{{ az_devops_agent_folder }}/.agent"
+  become: true
+  become_user: "{{ az_devops_agent_user }}"
+  when:
+    - az_devops_agent_role == 'deployment'
+    - (not service_is_installed) or reconfigure_or_replace
+
+- name: Configure agent as an environment resource
+  command: "{{ (agent_cmd_args + resource_agent_cmd_args) | join(' ') }}"
+  args:
+    chdir: "{{ az_devops_agent_folder }}"
+    creates: "{{ az_devops_agent_folder }}/.agent"
+  become: true
+  become_user: "{{ az_devops_agent_user }}"
+  when:
+    - az_devops_agent_role == 'resource'
+    - (not service_is_installed) or reconfigure_or_replace
+
+- name: Set provided user defined capabilities
+  ini_file:
+    path: "{{ az_devops_agent_folder }}/.env"
+    section: null
+    option: "{{ item.key }}"
+    value: "{{ item.value }}"
+    no_extra_spaces: yes
+    owner: "{{ az_devops_agent_user }}"
+    group: "{{ az_devops_agent_group }}"
+  loop: "{{ az_devops_agent_user_capabilities | default({}) | dict2items }}"
+  become: true
+
+- name: Install agent service
+  command: ./svc.sh install {{ az_devops_agent_user }}
+  become: true
+  become_user: "{{ az_devops_agent_user }}"
+  args:
+    chdir: "{{ az_devops_agent_folder }}"
+  when:
+    - (not service_is_installed) or reconfigure_or_replace
+
+- name: Start agent service
+  command: ./svc.sh start
+  become: true
+  become_user: "{{ az_devops_agent_user }}"
+  args:
+    chdir: "{{ az_devops_agent_folder }}"
+  when:
+    - (not service_is_running) or reconfigure_or_replace

--- a/tasks/Linux.yml
+++ b/tasks/Linux.yml
@@ -1,0 +1,185 @@
+- name: Add an agent user
+  user:
+    name: "{{ az_devops_agent_user }}"
+    comment: "Azure DevOps Agent"
+    shell: /bin/bash
+  become: true
+
+- name: Create directories
+  file:
+    state: directory
+    path: "{{ item }}"
+    owner: "{{ az_devops_agent_user }}"
+    group: "{{ az_devops_agent_user }}"
+    mode: 0755
+  loop:
+    - "{{ az_devops_agent_folder }}"
+    - "{{ az_devops_work_folder }}"
+  become: true
+
+- name: Download and unarchive
+  unarchive:
+    src: "{{ az_devops_agent_package_url }}"
+    dest: "{{ az_devops_agent_folder }}"
+    remote_src: yes
+    owner: "{{ az_devops_agent_user }}"
+    group: "{{ az_devops_agent_user }}"
+    creates: "{{ az_devops_agent_folder }}/config.sh"
+  become: true
+
+- name: Install dependencies via shipped script
+  command: ./bin/installdependencies.sh
+  become: true
+  args:
+    chdir: "{{ az_devops_agent_folder }}"
+  retries: 2
+  register: dep_install
+  until: dep_install is succeeded
+  changed_when:
+    - dep_install.stdout is regex("[1-9]\d* upgraded|[1-9]\d* newly installed")
+
+- name: Check if svc.sh exists
+  stat:
+    path: "{{ '/'.join((az_devops_agent_folder, 'svc.sh')) }}"
+  register: svc_sh
+  changed_when: false
+  check_mode: no
+
+- name: Check service status
+  command: ./svc.sh status
+  become: true
+  args:
+    chdir: "{{ az_devops_agent_folder }}"
+  register: svc_status
+  changed_when: false
+  check_mode: no
+  when: svc_sh.stat.exists
+
+- name: Set agent config facts
+  set_fact:
+    agent_cmd_args:
+      - "./config.sh"
+      - "--unattended"
+      - "--acceptteeeula"
+      - "--url '{{ az_devops_server_url }}'"
+      - "--work _work"
+      - "--auth PAT"
+      - "--token '{{ az_devops_accesstoken }}'"
+      - "--runasservice"
+    build_agent_cmd_args:
+      - "--pool '{{ az_devops_agent_pool_name }}'"
+      - "--agent '{{ az_devops_agent_name }}'"
+    deployment_agent_cmd_args:
+      - "--deploymentgroup"
+      - "--deploymentgroupname '{{ az_devops_deployment_group_name }}'"
+      - "--projectname '{{ az_devops_project_name }}'"
+    resource_agent_cmd_args:
+      - "--environment"
+      - "--environmentname '{{ az_devops_environment_name }}'"
+      - "--agent '{{ az_devops_agent_name }}'"
+      - "--projectname '{{ az_devops_project_name }}'"
+    service_is_installed: "{{ svc_status.stdout is defined and svc_status.stdout is not regex('not installed') }}"
+    service_is_running: "{{ svc_status.stdout is defined and svc_status.stdout is regex('active \\(running\\)') }}"
+    reconfigure_or_replace: "{{ az_devops_reconfigure_agent or az_devops_agent_replace_existing }}"
+
+- name: Add deployment group tags
+  set_fact:
+    deployment_agent_cmd_args: "{{ deployment_agent_cmd_args }} + ['--addDeploymentGroupTags', '--deploymentGroupTags \\'{{ az_devops_deployment_group_tags }}\\'']"
+  when:
+    - az_devops_deployment_group_tags is defined
+
+- name: Set proxy
+  set_fact:
+    agent_cmd_args: "{{ agent_cmd_args }} + ['--proxyurl \\'{{ az_devops_proxy_url }}\\'', '--proxyusername \\'{{ az_devops_proxy_username }}\\'', '--proxypassword \\'{{ az_devops_proxy_password }}\\'']"
+  when: 
+    - az_devops_proxy_url is defined
+
+- name: Uninstall agent service
+  command: ./svc.sh uninstall
+  become: true
+  args:
+    chdir: "{{ az_devops_agent_folder }}"
+    removes: "{{ az_devops_agent_folder }}/runsvc.sh"
+  when:
+    - service_is_installed
+    - reconfigure_or_replace
+
+- name: Unconfigure agent
+  command: "./config.sh remove --auth PAT --token {{ az_devops_accesstoken }}"
+  args:
+    chdir: "{{ az_devops_agent_folder }}"
+    removes: "{{ az_devops_agent_folder }}/.agent"
+  become: true
+  become_user: "{{ az_devops_agent_user }}"
+  when:
+    - service_is_installed
+    - reconfigure_or_replace
+
+- name: Add '--replace' configuration argument
+  set_fact:
+    build_agent_cmd_args: "{{ build_agent_cmd_args }} + ['--replace']"
+    deployment_agent_cmd_args: "{{ build_agent_cmd_args }} + ['--replace']"
+    resource_agent_cmd_args: "{{ resource_agent_cmd_args }} + ['--replace']"
+  when:
+    - az_devops_agent_replace_existing
+
+- name: Configure agent as a build server
+  command: "{{ (agent_cmd_args + build_agent_cmd_args) | join(' ') }}"
+  args:
+    chdir: "{{ az_devops_agent_folder }}"
+    creates: "{{ az_devops_agent_folder }}/.agent"
+  become: true
+  become_user: "{{ az_devops_agent_user }}"
+  when:
+    - az_devops_agent_role == 'build'
+    - (not service_is_installed) or reconfigure_or_replace
+
+- name: Configure agent as a deployment server
+  command: "{{ (agent_cmd_args + deployment_agent_cmd_args) | join(' ') }}"
+  args:
+    chdir: "{{ az_devops_agent_folder }}"
+    creates: "{{ az_devops_agent_folder }}/.agent"
+  become: true
+  become_user: "{{ az_devops_agent_user }}"
+  when:
+    - az_devops_agent_role == 'deployment'
+    - (not service_is_installed) or reconfigure_or_replace
+
+- name: Configure agent as an environment resource
+  command: "{{ (agent_cmd_args + resource_agent_cmd_args) | join(' ') }}"
+  args:
+    chdir: "{{ az_devops_agent_folder }}"
+    creates: "{{ az_devops_agent_folder }}/.agent"
+  become: true
+  become_user: "{{ az_devops_agent_user }}"
+  when:
+    - az_devops_agent_role == 'resource'
+    - (not service_is_installed) or reconfigure_or_replace
+
+- name: Set provided user defined capabilities
+  ini_file:
+    path: "{{ az_devops_agent_folder }}/.env"
+    section: null
+    option: "{{ item.key }}"
+    value: "{{ item.value }}"
+    no_extra_spaces: yes
+    owner: "{{ az_devops_agent_user }}"
+    group: "{{ az_devops_agent_user }}"
+  loop: "{{ az_devops_agent_user_capabilities | default({}) | dict2items }}"
+  become: true
+
+- name: Install agent service
+  command: ./svc.sh install {{ az_devops_agent_user }}
+  become: true
+  args:
+    chdir: "{{ az_devops_agent_folder }}"
+  when:
+    - (not service_is_installed) or reconfigure_or_replace
+
+- name: Start agent service
+  command: ./svc.sh start
+  become: true
+  args:
+    chdir: "{{ az_devops_agent_folder }}"
+  when:
+    - (not service_is_running) or reconfigure_or_replace

--- a/tasks/Linux.yml
+++ b/tasks/Linux.yml
@@ -10,7 +10,7 @@
     state: directory
     path: "{{ item }}"
     owner: "{{ az_devops_agent_user }}"
-    group: "{{ az_devops_agent_user }}"
+    group: "{{ az_devops_agent_group }}"
     mode: 0755
   loop:
     - "{{ az_devops_agent_folder }}"
@@ -23,7 +23,7 @@
     dest: "{{ az_devops_agent_folder }}"
     remote_src: yes
     owner: "{{ az_devops_agent_user }}"
-    group: "{{ az_devops_agent_user }}"
+    group: "{{ az_devops_agent_group }}"
     creates: "{{ az_devops_agent_folder }}/config.sh"
   become: true
 
@@ -160,7 +160,7 @@
     value: "{{ item.value }}"
     no_extra_spaces: yes
     owner: "{{ az_devops_agent_user }}"
-    group: "{{ az_devops_agent_user }}"
+    group: "{{ az_devops_agent_group }}"
   loop: "{{ az_devops_agent_user_capabilities | default({}) | dict2items }}"
   become: true
 

--- a/tasks/Linux.yml
+++ b/tasks/Linux.yml
@@ -27,21 +27,17 @@
     creates: "{{ az_devops_agent_folder }}/config.sh"
   become: true
 
-- name: Install dependencies via shipped script
-  command: ./bin/installdependencies.sh
+- name: Install dependencies
+  package:
+    name: "{{ az_devops_agent_dependencies }}"
+    state: latest
   become: true
-  args:
-    chdir: "{{ az_devops_agent_folder }}"
-  retries: 2
-  register: dep_install
-  until: dep_install is succeeded
-  changed_when:
-    - dep_install.stdout is regex("[1-9]\d* upgraded|[1-9]\d* newly installed")
 
 - name: Check if svc.sh exists
   stat:
     path: "{{ '/'.join((az_devops_agent_folder, 'svc.sh')) }}"
   register: svc_sh
+  become: true
   changed_when: false
   check_mode: no
 

--- a/tasks/Windows.yml
+++ b/tasks/Windows.yml
@@ -1,0 +1,94 @@
+- name: Add an agent user
+  win_user:
+    name: "{{ az_devops_agent_user }}"
+    password: "{{ az_devops_agent_password }}"
+    state: present
+    expires: -1
+  become: yes
+
+- name: Ensure chocolatey is present
+  win_chocolatey:
+    name: chocolatey
+    state: present
+
+# The full list of parameters is documented here:
+# https://github.com/flcdrg/au-packages/blob/master/azure-pipelines-agent/README.md
+
+- name: Set basic agent package parameters
+  set_fact:
+    common_install_options:
+      - "/Directory:{{ az_devops_agent_folder }}"
+      - "/Url:{{ az_devops_server_url }}"
+      - "/Token:{{ az_devops_accesstoken }}"
+      - "/Auth:PAT"
+      - "/Pool:{{ az_devops_agent_pool_name }}"
+      - "/Work:_work"
+      - "/LogonAccount:{{ az_devops_agent_user }}"
+      - "/LogonPassword:{{ az_devops_agent_password }}"
+    build_agent_install_options:
+      - "/Pool:{{ az_devops_agent_pool_name }}"
+      - "/AgentName:{{ az_devops_agent_name }}"
+    deployment_install_options:
+      - "/DeploymentGroup"
+      - "/DeploymentGroupName:{{ az_devops_deployment_group_name }}"
+      - "/ProjectName:{{ az_devops_project_name }}"
+    resource_agent_install_options:
+      - "/Environment"
+      - "/EnvironmentName:{{ az_devops_environment_name }}"
+      - "/AgentName:{{ az_devops_agent_name }}"
+      - "/ProjectName:{{ az_devops_project_name }}"
+
+- name: Add '/Replace' configuration argument
+  set_fact:
+    common_install_options: "{{ common_install_options }} + ['/Replace']"
+  when:
+    - az_devops_agent_replace_existing
+
+- name: Add deployment group tags
+  set_fact:
+    deployment_install_options: "{{ deployment_install_options }} + ['/DeploymentGroupTags:{{ az_devops_deployment_group_tags }}']"
+  when:
+    - az_devops_deployment_group_tags is defined
+
+- name: Add az_devops_proxy_url
+  set_fact:
+    common_install_options: "{{ common_install_options }} + ['/ProxyUrl:{{ az_devops_proxy_url }}']"
+  when:
+    - az_devops_proxy_url is defined and az_devops_proxy_url
+
+- name: Add az_devops_proxy_username
+  set_fact:
+    common_install_options: "{{ common_install_options }} + ['/ProxyUserName:{{ az_devops_proxy_username }}']"
+  when:
+    - az_devops_proxy_username is defined and az_devops_proxy_username
+
+- name: Add az_devops_proxy_password
+  set_fact:
+    common_install_options: "{{ common_install_options }} + ['/ProxyPassword:{{ az_devops_proxy_password }}']"
+  when:
+    - az_devops_proxy_password is defined and az_devops_proxy_password
+
+- name: Configure agent as a build server
+  set_fact:
+    az_devops_agent_package_params: "{{ common_install_options }} + {{ build_agent_install_options }}"
+  when:
+     - az_devops_agent_role == 'build'
+
+- name: Configure agent as a deployment server
+  set_fact:
+    az_devops_agent_package_params: "{{ common_install_options }} + {{ deployment_install_options }}"
+  when:
+     - az_devops_agent_role == 'deployment'
+
+- name: Configure agent as an environment resource
+  set_fact:
+    az_devops_agent_package_params: "{{ common_install_options }} + {{ resource_agent_install_options }}"
+  when:
+     - az_devops_agent_role == 'resource'
+
+- name: Install azure-pipelines-agent package
+  win_chocolatey:
+    name: azure-pipelines-agent
+    state: present
+    version: '{{az_devops_agent_version}}'
+    package_params: "{{ az_devops_agent_package_params | join(' ') }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -11,6 +11,27 @@
   loop_control:
     loop_var: varfile
 
+# - debug:
+#     msg:
+#     - "Dependency lookup variables are :"
+#     - "ansible_distribution: {{ ansible_distribution }}"
+#     - "ansible_distribution_major_version: {{ ansible_distribution_major_version }}"
+#     - "ansible_os_family: {{ ansible_os_family }}"
+#     - "ansible_system: {{ ansible_system }}"
+
+- name: Read platform-specific package list variables
+  include_vars: "{{ varfile }}"
+  with_first_found:
+    - files:
+        - "dependencies-{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
+        - "dependencies-{{ ansible_distribution }}.yml"
+        - "dependencies-{{ ansible_os_family }}-{{ ansible_distribution_major_version }}.yml"
+        - "dependencies-{{ ansible_os_family }}.yml"
+        - "dependencies-{{ ansible_system }}.yml"
+      skip: true
+  loop_control:
+    loop_var: varfile
+
 - name: Read platform specific tasks
   include_tasks: "{{ taskfile }}"
   with_first_found:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,185 +1,22 @@
-- name: Add an agent user
-  user:
-    name: "{{ az_devops_agent_user }}"
-    comment: "Azure DevOps Agent"
-    shell: /bin/bash
-  become: true
+---
+- name: Read platform-specific variables
+  include_vars: "{{ varfile }}"
+  with_first_found:
+    - files:
+        - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
+        - "{{ ansible_distribution }}.yml"
+        - "{{ ansible_os_family }}.yml"
+        - "{{ ansible_system }}.yml"
+      skip: true
+  loop_control:
+    loop_var: varfile
 
-- name: Create directories
-  file:
-    state: directory
-    path: "{{ item }}"
-    owner: "{{ az_devops_agent_user }}"
-    group: "{{ az_devops_agent_user }}"
-    mode: 0755
-  loop:
-    - "{{ az_devops_agent_folder }}"
-    - "{{ az_devops_work_folder }}"
-  become: true
-
-- name: Download and unarchive
-  unarchive:
-    src: "{{ az_devops_agent_package_url }}"
-    dest: "{{ az_devops_agent_folder }}"
-    remote_src: yes
-    owner: "{{ az_devops_agent_user }}"
-    group: "{{ az_devops_agent_user }}"
-    creates: "{{ az_devops_agent_folder }}/config.sh"
-  become: true
-
-- name: Install dependencies via shipped script
-  command: ./bin/installdependencies.sh
-  become: true
-  args:
-    chdir: "{{ az_devops_agent_folder }}"
-  retries: 2
-  register: dep_install
-  until: dep_install is succeeded
-  changed_when:
-    - dep_install.stdout is regex("[1-9]\d* upgraded|[1-9]\d* newly installed")
-
-- name: Check if svc.sh exists
-  stat:
-    path: "{{ '/'.join((az_devops_agent_folder, 'svc.sh')) }}"
-  register: svc_sh
-  changed_when: false
-  check_mode: no
-
-- name: Check service status
-  command: ./svc.sh status
-  become: true
-  args:
-    chdir: "{{ az_devops_agent_folder }}"
-  register: svc_status
-  changed_when: false
-  check_mode: no
-  when: svc_sh.stat.exists
-
-- name: Set agent config facts
-  set_fact:
-    agent_cmd_args:
-      - "./config.sh"
-      - "--unattended"
-      - "--acceptteeeula"
-      - "--url '{{ az_devops_server_url }}'"
-      - "--work _work"
-      - "--auth PAT"
-      - "--token '{{ az_devops_accesstoken }}'"
-      - "--runasservice"
-    build_agent_cmd_args:
-      - "--pool '{{ az_devops_agent_pool_name }}'"
-      - "--agent '{{ az_devops_agent_name }}'"
-    deployment_agent_cmd_args:
-      - "--deploymentgroup"
-      - "--deploymentgroupname '{{ az_devops_deployment_group_name }}'"
-      - "--projectname '{{ az_devops_project_name }}'"
-    resource_agent_cmd_args:
-      - "--environment"
-      - "--environmentname '{{ az_devops_environment_name }}'"
-      - "--agent '{{ az_devops_agent_name }}'"
-      - "--projectname '{{ az_devops_project_name }}'"
-    service_is_installed: "{{ svc_status.stdout is defined and svc_status.stdout is not regex('not installed') }}"
-    service_is_running: "{{ svc_status.stdout is defined and svc_status.stdout is regex('active \\(running\\)') }}"
-    reconfigure_or_replace: "{{ az_devops_reconfigure_agent or az_devops_agent_replace_existing }}"
-
-- name: Add deployment group tags
-  set_fact:
-    deployment_agent_cmd_args: "{{ deployment_agent_cmd_args }} + ['--addDeploymentGroupTags', '--deploymentGroupTags \\'{{ az_devops_deployment_group_tags }}\\'']"
-  when:
-    - az_devops_deployment_group_tags is defined
-
-- name: Set proxy
-  set_fact:
-    agent_cmd_args: "{{ agent_cmd_args }} + ['--proxyurl \\'{{ az_devops_proxy_url }}\\'', '--proxyusername \\'{{ az_devops_proxy_username }}\\'', '--proxypassword \\'{{ az_devops_proxy_password }}\\'']"
-  when: 
-    - az_devops_proxy_url is defined
-
-- name: Uninstall agent service
-  command: ./svc.sh uninstall
-  become: true
-  args:
-    chdir: "{{ az_devops_agent_folder }}"
-    removes: "{{ az_devops_agent_folder }}/runsvc.sh"
-  when:
-    - service_is_installed
-    - reconfigure_or_replace
-
-- name: Unconfigure agent
-  command: "./config.sh remove --auth PAT --token {{ az_devops_accesstoken }}"
-  args:
-    chdir: "{{ az_devops_agent_folder }}"
-    removes: "{{ az_devops_agent_folder }}/.agent"
-  become: true
-  become_user: "{{ az_devops_agent_user }}"
-  when:
-    - service_is_installed
-    - reconfigure_or_replace
-
-- name: Add '--replace' configuration argument
-  set_fact:
-    build_agent_cmd_args: "{{ build_agent_cmd_args }} + ['--replace']"
-    deployment_agent_cmd_args: "{{ build_agent_cmd_args }} + ['--replace']"
-    resource_agent_cmd_args: "{{ resource_agent_cmd_args }} + ['--replace']"
-  when:
-    - az_devops_agent_replace_existing
-
-- name: Configure agent as a build server
-  command: "{{ (agent_cmd_args + build_agent_cmd_args) | join(' ') }}"
-  args:
-    chdir: "{{ az_devops_agent_folder }}"
-    creates: "{{ az_devops_agent_folder }}/.agent"
-  become: true
-  become_user: "{{ az_devops_agent_user }}"
-  when:
-    - az_devops_agent_role == 'build'
-    - (not service_is_installed) or reconfigure_or_replace
-
-- name: Configure agent as a deployment server
-  command: "{{ (agent_cmd_args + deployment_agent_cmd_args) | join(' ') }}"
-  args:
-    chdir: "{{ az_devops_agent_folder }}"
-    creates: "{{ az_devops_agent_folder }}/.agent"
-  become: true
-  become_user: "{{ az_devops_agent_user }}"
-  when:
-    - az_devops_agent_role == 'deployment'
-    - (not service_is_installed) or reconfigure_or_replace
-
-- name: Configure agent as an environment resource
-  command: "{{ (agent_cmd_args + resource_agent_cmd_args) | join(' ') }}"
-  args:
-    chdir: "{{ az_devops_agent_folder }}"
-    creates: "{{ az_devops_agent_folder }}/.agent"
-  become: true
-  become_user: "{{ az_devops_agent_user }}"
-  when:
-    - az_devops_agent_role == 'resource'
-    - (not service_is_installed) or reconfigure_or_replace
-
-- name: Set provided user defined capabilities
-  ini_file:
-    path: "{{ az_devops_agent_folder }}/.env"
-    section: null
-    option: "{{ item.key }}"
-    value: "{{ item.value }}"
-    no_extra_spaces: yes
-    owner: "{{ az_devops_agent_user }}"
-    group: "{{ az_devops_agent_user }}"
-  loop: "{{ az_devops_agent_user_capabilities | default({}) | dict2items }}"
-  become: true
-
-- name: Install agent service
-  command: ./svc.sh install {{ az_devops_agent_user }}
-  become: true
-  args:
-    chdir: "{{ az_devops_agent_folder }}"
-  when:
-    - (not service_is_installed) or reconfigure_or_replace
-
-- name: Start agent service
-  command: ./svc.sh start
-  become: true
-  args:
-    chdir: "{{ az_devops_agent_folder }}"
-  when:
-    - (not service_is_running) or reconfigure_or_replace
+- name: Read platform specific tasks
+  include_tasks: "{{ taskfile }}"
+  with_first_found:
+    - "{{ ansible_distribution }}-{{ ansible_distribution_major_version }}.yml"
+    - "{{ ansible_distribution }}.yml"
+    - "{{ ansible_os_family }}.yml"
+    - "{{ ansible_system }}.yml"
+  loop_control:
+    loop_var: taskfile

--- a/vars/Darwin.yml
+++ b/vars/Darwin.yml
@@ -1,0 +1,6 @@
+az_devops_default_agent_folder: "/Users/{{ az_devops_agent_user }}/agent/"
+az_devops_default_work_folder: "/Users/{{ az_devops_agent_user }}/agent/_work"
+az_devops_launchagent_folder: "/Users/{{ az_devops_agent_user }}/Library/LaunchAgents"
+az_devops_default_agent_package_url: "https://vstsagentpackage.azureedge.net/agent/{{ az_devops_agent_version }}/vsts-agent-osx-x64-{{ az_devops_agent_version }}.tar.gz"
+az_devops_default_agent_local_package: "/Users/{{ az_devops_agent_user }}/vsts-agent-osx-x64-{{ az_devops_agent_version }}.tar.gz"
+az_devops_default_agent_group: admin

--- a/vars/Linux.yml
+++ b/vars/Linux.yml
@@ -1,3 +1,4 @@
 az_devops_default_agent_folder: "/home/{{ az_devops_agent_user }}/agent/"
 az_devops_default_work_folder: "/home/{{ az_devops_agent_user }}/agent/_work"
 az_devops_default_agent_package_url: "https://vstsagentpackage.azureedge.net/agent/{{ az_devops_agent_version }}/vsts-agent-linux-x64-{{ az_devops_agent_version }}.tar.gz"
+az_devops_default_agent_group: "{{ az_devops_agent_user }}"

--- a/vars/Linux.yml
+++ b/vars/Linux.yml
@@ -1,0 +1,2 @@
+az_devops_default_agent_folder: "/home/{{ az_devops_agent_user }}/agent/"
+az_devops_default_work_folder: "/home/{{ az_devops_agent_user }}/agent/_work"

--- a/vars/Linux.yml
+++ b/vars/Linux.yml
@@ -1,2 +1,3 @@
 az_devops_default_agent_folder: "/home/{{ az_devops_agent_user }}/agent/"
 az_devops_default_work_folder: "/home/{{ az_devops_agent_user }}/agent/_work"
+az_devops_default_agent_package_url: "https://vstsagentpackage.azureedge.net/agent/{{ az_devops_agent_version }}/vsts-agent-linux-x64-{{ az_devops_agent_version }}.tar.gz"

--- a/vars/Windows.yml
+++ b/vars/Windows.yml
@@ -1,0 +1,5 @@
+az_devops_default_agent_folder: "C:/a"
+az_devops_default_work_folder: "C:/w"
+az_devops_default_agent_package_url: "https://vstsagentpackage.azureedge.net/agent/{{ az_devops_agent_version }}/vsts-agent-win-x64-{{ az_devops_agent_version }}.zip"
+az_devops_default_agent_local_package: "C:/vsts-agent-win-x64-{{ az_devops_agent_version }}.zip"
+az_devops_default_agent_group: "{{ az_devops_agent_user }}"

--- a/vars/dependencies-Debian-10.yml
+++ b/vars/dependencies-Debian-10.yml
@@ -1,0 +1,5 @@
+az_devops_agent_dependencies:
+  - libcurl4
+  - libgssapi-krb5-2
+  - libicu63
+  - libssl1.1

--- a/vars/dependencies-Debian-9.yml
+++ b/vars/dependencies-Debian-9.yml
@@ -1,0 +1,5 @@
+az_devops_agent_dependencies:
+  - libcurl3
+  - libgssapi-krb5-2
+  - libicu57
+  - libssl1.1

--- a/vars/dependencies-RedHat-7.yml
+++ b/vars/dependencies-RedHat-7.yml
@@ -1,0 +1,6 @@
+az_devops_agent_dependencies:
+  - krb5-libs
+  - libicu
+  - lttng-ust
+  - openssl-libs
+  - zlib

--- a/vars/dependencies-Ubuntu-16.yml
+++ b/vars/dependencies-Ubuntu-16.yml
@@ -1,0 +1,5 @@
+az_devops_agent_dependencies:
+  - libcurl3
+  - libgssapi-krb5-2
+  - libicu55
+  - libssl1.0.0

--- a/vars/dependencies-Ubuntu-18.yml
+++ b/vars/dependencies-Ubuntu-18.yml
@@ -1,0 +1,5 @@
+az_devops_agent_dependencies:
+  - libcurl3
+  - libgssapi-krb5-2
+  - libicu60
+  - libssl1.1

--- a/vars/dependencies-Ubuntu-20.yml
+++ b/vars/dependencies-Ubuntu-20.yml
@@ -1,0 +1,5 @@
+az_devops_agent_dependencies:
+  - libcurl3
+  - libgssapi-krb5-2
+  - libicu66
+  - libssl1.1


### PR DESCRIPTION
Hi, as part of my work as 'DevOps guy' at [CCDC](https://www.ccdc.cam.ac.uk/), I've been asked to provision the vsts agent on multiple operating systems.
This required adding support for macos and windows. (hence #37)
Given we use ubuntu 20.04 vms, we also needed a solution for #20 

I thus decided to avoid using the installdependencies.sh script and used the ansible package module.

To decide what packages to install, I used a technique we've used successfully in other occasions, which is to load defaults variables based on Distribution, Distribution family, operating system, adding in version specific details. This creates a bit of file churn but makes it very easy to add a different distribution.

For windows, I found it easier to use chocolatey to install the agent, reducing a lot of the complexity in downloading and extracting the files.

I tested the changes using vagrant on:
- Ubuntu 16.04, 18.04, 20.04 (couldn't test 14.04 as I had issues connecting via ssh to it) (using bento boxes)
- Centos 7 (using bento boxes)
- Debian 9 and 10 (using bento boxes)
- MacOS 10.15 (using our internal vagrant box)
- Windows 2019 server (using our internal vagrant box based on StefanScherer/packer-windows)

<img width="1015" alt="Screenshot 2020-10-16 at 11 48 20" src="https://user-images.githubusercontent.com/111884/96246991-238d7300-0fb2-11eb-982c-265d74c26928.png">
