### PR TITLE
Dependency correction and linting fix

### DIFF
--- a/tasks/Darwin.yml
+++ b/tasks/Darwin.yml
@@ -38,6 +38,7 @@
   become: true
   become_user: "{{ az_devops_agent_user }}"
   when: agent_download.changed or agent_directory.changed
+  tags: ['skip_ansible_lint']
 
 - name: Check if svc.sh exists
   stat:
@@ -78,7 +79,7 @@
       - "--projectname '{{ az_devops_project_name }}'"
     resource_agent_cmd_args:
       - "--environment"
-      - "--environmentname '{{ az_devops_environment_name }}'"
+      - "--environmentname '{{ az_devops_environment_name }}'"
       - "--agent '{{ az_devops_agent_name }}'"
       - "--projectname '{{ az_devops_project_name }}'"
     service_is_installed: "{{ svc_status.stdout is defined and svc_status.stdout is not regex('not installed') }}"
@@ -87,14 +88,16 @@
 
 - name: Add deployment group tags
   set_fact:
-    deployment_agent_cmd_args: "{{ deployment_agent_cmd_args }} + ['--addDeploymentGroupTags', '--deploymentGroupTags \\'{{ az_devops_deployment_group_tags }}\\'']"
+    deployment_agent_cmd_args: "{{ deployment_agent_cmd_args }} +
+      ['--addDeploymentGroupTags', '--deploymentGroupTags \\'{{ az_devops_deployment_group_tags }}\\'']"
   when:
     - az_devops_deployment_group_tags is defined
 
 - name: Set proxy
   set_fact:
-    agent_cmd_args: "{{ agent_cmd_args }} + ['--proxyurl \\'{{ az_devops_proxy_url }}\\'', '--proxyusername \\'{{ az_devops_proxy_username }}\\'', '--proxypassword \\'{{ az_devops_proxy_password }}\\'']"
-  when: 
+    agent_cmd_args: "{{ agent_cmd_args }} + ['--proxyurl \\'{{ az_devops_proxy_url }}\\'',
+      '--proxyusername \\'{{ az_devops_proxy_username }}\\'', '--proxypassword \\'{{ az_devops_proxy_password }}\\'']"
+  when:
     - az_devops_proxy_url is defined
 
 - name: Uninstall agent service

--- a/tasks/Linux.yml
+++ b/tasks/Linux.yml
@@ -30,7 +30,7 @@
 - name: Install dependencies
   package:
     name: "{{ az_devops_agent_dependencies }}"
-    state: latest
+    state: present
   become: true
 
 - name: Check if svc.sh exists
@@ -71,7 +71,7 @@
       - "--projectname '{{ az_devops_project_name }}'"
     resource_agent_cmd_args:
       - "--environment"
-      - "--environmentname '{{ az_devops_environment_name }}'"
+      - "--environmentname '{{ az_devops_environment_name }}'"
       - "--agent '{{ az_devops_agent_name }}'"
       - "--projectname '{{ az_devops_project_name }}'"
     service_is_installed: "{{ svc_status.stdout is defined and svc_status.stdout is not regex('not installed') }}"
@@ -80,14 +80,16 @@
 
 - name: Add deployment group tags
   set_fact:
-    deployment_agent_cmd_args: "{{ deployment_agent_cmd_args }} + ['--addDeploymentGroupTags', '--deploymentGroupTags \\'{{ az_devops_deployment_group_tags }}\\'']"
+    deployment_agent_cmd_args: "{{ deployment_agent_cmd_args }} +
+      ['--addDeploymentGroupTags', '--deploymentGroupTags \\'{{ az_devops_deployment_group_tags }}\\'']"
   when:
     - az_devops_deployment_group_tags is defined
 
 - name: Set proxy
   set_fact:
-    agent_cmd_args: "{{ agent_cmd_args }} + ['--proxyurl \\'{{ az_devops_proxy_url }}\\'', '--proxyusername \\'{{ az_devops_proxy_username }}\\'', '--proxypassword \\'{{ az_devops_proxy_password }}\\'']"
-  when: 
+    agent_cmd_args: "{{ agent_cmd_args }} + ['--proxyurl \\'{{ az_devops_proxy_url }}\\'',
+      '--proxyusername \\'{{ az_devops_proxy_username }}\\'', '--proxypassword \\'{{ az_devops_proxy_password }}\\'']"
+  when:
     - az_devops_proxy_url is defined
 
 - name: Uninstall agent service

--- a/tasks/Windows.yml
+++ b/tasks/Windows.yml
@@ -34,7 +34,7 @@
       - "/ProjectName:{{ az_devops_project_name }}"
     resource_agent_install_options:
       - "/Environment"
-      - "/EnvironmentName:{{ az_devops_environment_name }}"
+      - "/EnvironmentName:{{ az_devops_environment_name }}"
       - "/AgentName:{{ az_devops_agent_name }}"
       - "/ProjectName:{{ az_devops_project_name }}"
 
@@ -90,5 +90,5 @@
   win_chocolatey:
     name: azure-pipelines-agent
     state: present
-    version: '{{az_devops_agent_version}}'
+    version: "{{ az_devops_agent_version }}"
     package_params: "{{ az_devops_agent_package_params | join(' ') }}"

--- a/vars/dependencies-Ubuntu-18.yml
+++ b/vars/dependencies-Ubuntu-18.yml
@@ -1,5 +1,5 @@
 az_devops_agent_dependencies:
-  - libcurl3
+  - libcurl4
   - libgssapi-krb5-2
   - libicu60
   - libssl1.1

--- a/vars/dependencies-Ubuntu-20.yml
+++ b/vars/dependencies-Ubuntu-20.yml
@@ -1,5 +1,5 @@
 az_devops_agent_dependencies:
-  - libcurl3
+  - libcurl4
   - libgssapi-krb5-2
   - libicu66
   - libssl1.1


### PR DESCRIPTION
First commit is addressing dependencies issue on Ubuntu-18 and Ubuntu-20 for libcurl3.
- On Ubuntu-18 - libcurl3 causes "curl" uninstallation, since lubcurl4 is default
- On Ubuntu-20 - libcurl3 does not exist, so installation is failing.

using libcurl4 fixes both issues.

Second commit is more formatting related (all the issues reported by default ansible lint on Ubuntu-20):
- spaces and lines to loon
- usage of 'latest' for dependencies (replaced with 'present')
- single exclusion of lint added for unarchive task on Darwin
