### PR TITLE
Use Windows-compatible password expiration parameter

### DIFF
--- a/tasks/Windows.yml
+++ b/tasks/Windows.yml
@@ -3,7 +3,7 @@
     name: "{{ az_devops_agent_user }}"
     password: "{{ az_devops_agent_password }}"
     state: present
-    expires: -1
+    password_never_expires: true
   become: yes
 
 - name: Ensure chocolatey is present


### PR DESCRIPTION
In Windows.yml, use [`password_never_expires: true`](https://docs.ansible.com/ansible/latest/collections/ansible/windows/win_user_module.html#parameter-password_never_expires) instead of [`expires: -1`](https://docs.ansible.com/ansible/latest/collections/ansible/builtin/user_module.html#parameter-expires).

`expires: -1` is only compatible with the Linux user module, and `password_never_expires` is the Windows-compatible equivalent.