### PR TITLE
add support for Ubuntu 21.04

### DIFF
--- a/vars/dependencies-Ubuntu-21.yml
+++ b/vars/dependencies-Ubuntu-21.yml
@@ -1,0 +1,6 @@
+az_devops_agent_dependencies:
+  - libcurl4
+  - libgssapi-krb5-2
+  - libicu67
+  - libssl1.1
+  - acl


### PR DESCRIPTION
add a dependencies YAML file for Ubuntu 21.04. upgrade the `libicu66` to `libicu67`.