### PR TITLE
update ini task to use fully qualified role name

### DIFF
--- a/tasks/Linux.yml
+++ b/tasks/Linux.yml
@@ -177,7 +177,7 @@
     - (not service_is_installed) or reconfigure_or_replace
 
 - name: Set provided user defined capabilities
-  ini_file:
+  community.general.ini_file:
     path: "{{ az_devops_agent_folder }}/.env"
     section: null
     option: "{{ item.key }}"


### PR DESCRIPTION
This fixes the role to work on ansible 4.4.0 and ansible-core 2.11.4.