### PR TITLE
Enable disabling creation of local windows account 

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -17,3 +17,4 @@ az_devops_deployment_group_tags: null
 az_devops_proxy_url: null
 az_devops_proxy_username: null
 az_devops_proxy_password: null
+az_devops_agent_create_local_user: true

--- a/tasks/Windows.yml
+++ b/tasks/Windows.yml
@@ -6,7 +6,7 @@
     password_never_expires: true
   become: yes
   when:
-    - az_devops_agent_user_required
+    - az_devops_agent_create_local_user
     
 - name: Ensure chocolatey is present
   win_chocolatey:

--- a/tasks/Windows.yml
+++ b/tasks/Windows.yml
@@ -5,7 +5,9 @@
     state: present
     password_never_expires: true
   become: yes
-
+  when:
+    - az_devops_agent_user_required
+    
 - name: Ensure chocolatey is present
   win_chocolatey:
     name: chocolatey

--- a/vars/Windows.yml
+++ b/vars/Windows.yml
@@ -3,3 +3,4 @@ az_devops_default_work_folder: "C:/w"
 az_devops_default_agent_package_url: "https://vstsagentpackage.azureedge.net/agent/{{ az_devops_agent_version }}/vsts-agent-win-x64-{{ az_devops_agent_version }}.zip"
 az_devops_default_agent_local_package: "C:/vsts-agent-win-x64-{{ az_devops_agent_version }}.zip"
 az_devops_default_agent_group: "{{ az_devops_agent_user }}"
+az_devops_agent_user_required: true

--- a/vars/Windows.yml
+++ b/vars/Windows.yml
@@ -3,4 +3,3 @@ az_devops_default_work_folder: "C:/w"
 az_devops_default_agent_package_url: "https://vstsagentpackage.azureedge.net/agent/{{ az_devops_agent_version }}/vsts-agent-win-x64-{{ az_devops_agent_version }}.zip"
 az_devops_default_agent_local_package: "C:/vsts-agent-win-x64-{{ az_devops_agent_version }}.zip"
 az_devops_default_agent_group: "{{ az_devops_agent_user }}"
-az_devops_agent_user_required: true


### PR DESCRIPTION
I'd like my agent service to run under a service account, so don't need a local user account created.