### PR TITLE
tasks/Linux: add user primary group before adding a user

### DIFF
--- a/tasks/Linux.yml
+++ b/tasks/Linux.yml
@@ -1,3 +1,9 @@
+- name: Add an agent user group
+  group:
+    name: "{{ az_devops_agent_group }}"
+    state: present
+  become: true
+
 - name: Add an agent user
   user:
     name: "{{ az_devops_agent_user }}"


### PR DESCRIPTION
I'm not sure if this is the right way to fix the issue, if we want to create a specific primary group I would expect it to do it automatically. If group already exists this wouldn't make any issues as far as I know.


Fixes: #59