### PR TITLE
Update to work with latest ansible.

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,6 +17,7 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+        - 8
     - name: Debian
       versions:
         - stretch

--- a/tasks/Darwin.yml
+++ b/tasks/Darwin.yml
@@ -89,17 +89,15 @@
 
 - name: Add deployment group tags
   set_fact:
-    deployment_agent_cmd_args: "{{ deployment_agent_cmd_args }} +
-      ['--addDeploymentGroupTags', '--deploymentGroupTags \\'{{ az_devops_deployment_group_tags }}\\'']"
+    deployment_agent_cmd_args: "{{ deployment_agent_cmd_args + ['--addDeploymentGroupTags', '--deploymentGroupTags', az_devops_deployment_group_tags'] }}"
   when:
-    - az_devops_deployment_group_tags is defined
+    - az_devops_deployment_group_tags is defined and az_devops_deployment_group_tags != None
 
 - name: Set proxy
   set_fact:
-    agent_cmd_args: "{{ agent_cmd_args }} + ['--proxyurl \\'{{ az_devops_proxy_url }}\\'',
-      '--proxyusername \\'{{ az_devops_proxy_username }}\\'', '--proxypassword \\'{{ az_devops_proxy_password }}\\'']"
+    agent_cmd_args: "{{ agent_cmd_args + ['--proxyurl', az_devops_proxy_url, '--proxyusername', az_devops_proxy_username, '--proxypassword', az_devops_proxy_password] }}"
   when:
-    - az_devops_proxy_url is defined
+    - az_devops_proxy_url is defined and az_devops_proxy_url != None
 
 - name: Uninstall agent service
   command: ./svc.sh uninstall
@@ -125,9 +123,9 @@
 
 - name: Add '--replace' configuration argument
   set_fact:
-    build_agent_cmd_args: "{{ build_agent_cmd_args }} + ['--replace']"
-    deployment_agent_cmd_args: "{{ build_agent_cmd_args }} + ['--replace']"
-    resource_agent_cmd_args: "{{ resource_agent_cmd_args }} + ['--replace']"
+    build_agent_cmd_args: "{{ build_agent_cmd_args + ['--replace'] }}"
+    deployment_agent_cmd_args: "{{ build_agent_cmd_args + ['--replace'] }}"
+    resource_agent_cmd_args: "{{ resource_agent_cmd_args + ['--replace'] }}"
   when:
     - az_devops_agent_replace_existing
 

--- a/tasks/Darwin.yml
+++ b/tasks/Darwin.yml
@@ -93,11 +93,17 @@
   when:
     - az_devops_deployment_group_tags is defined and az_devops_deployment_group_tags != None
 
-- name: Set proxy
+- name: Set proxy url
   set_fact:
-    agent_cmd_args: "{{ agent_cmd_args + ['--proxyurl', az_devops_proxy_url, '--proxyusername', az_devops_proxy_username, '--proxypassword', az_devops_proxy_password] }}"
+    agent_cmd_args: "{{ agent_cmd_args + ['--proxyurl', az_devops_proxy_url] }}"
   when:
     - az_devops_proxy_url is defined and az_devops_proxy_url != None
+
+- name: Set proxy username and password
+  set_fact:
+    agent_cmd_args: "{{ agent_cmd_args + ['--proxyusername', az_devops_proxy_username, '--proxypassword', az_devops_proxy_password] }}"
+  when:
+    - az_devops_proxy_url is defined and az_devops_proxy_url != None and az_devops_proxy_username != None and az_devops_proxy_password != None
 
 - name: Uninstall agent service
   command: ./svc.sh uninstall

--- a/tasks/Linux.yml
+++ b/tasks/Linux.yml
@@ -103,11 +103,17 @@
   when:
     - az_devops_deployment_group_tags is defined and az_devops_deployment_group_tags != None
 
-- name: Set proxy
+- name: Set proxy url
   set_fact:
-    agent_cmd_args: "{{ agent_cmd_args + ['--proxyurl',  az_devops_proxy_url, '--proxyusername', az_devops_proxy_username, '--proxypassword', az_devops_proxy_password ] }}"
+    agent_cmd_args: "{{ agent_cmd_args + ['--proxyurl',  az_devops_proxy_url] }}"
   when:
     - az_devops_proxy_url is defined and az_devops_proxy_url != None
+
+- name: Set proxy user and password
+  set_fact:
+    agent_cmd_args: "{{ agent_cmd_args + ['--proxyusername', az_devops_proxy_username, '--proxypassword', az_devops_proxy_password ] }}"
+  when:
+    - az_devops_proxy_url is defined and az_devops_proxy_url != None and az_devops_proxy_username != None and az_devops_proxy_password != None
 
 - name: Download {{ az_devops_agent_package_url }}
   get_url:

--- a/tasks/Linux.yml
+++ b/tasks/Linux.yml
@@ -99,8 +99,7 @@
 
 - name: Add deployment group tags
   set_fact:
-    deployment_agent_cmd_args: "{{ deployment_agent_cmd_args +
-      ['--addDeploymentGroupTags', '--deploymentGroupTags', az_devops_deployment_group_tags ] }}"
+    deployment_agent_cmd_args: "{{ deployment_agent_cmd_args + ['--addDeploymentGroupTags', '--deploymentGroupTags', az_devops_deployment_group_tags ] }}"
   when:
     - az_devops_deployment_group_tags is defined and az_devops_deployment_group_tags != None
 

--- a/tasks/Linux.yml
+++ b/tasks/Linux.yml
@@ -1,3 +1,8 @@
+- name: Create group {{ az_devops_agent_group }}
+  group:
+    name: "{{ az_devops_agent_group }}"
+    state: present
+
 - name: Add an agent user
   user:
     name: "{{ az_devops_agent_user }}"
@@ -94,20 +99,25 @@
 
 - name: Add deployment group tags
   set_fact:
-    deployment_agent_cmd_args: "{{ deployment_agent_cmd_args }} +
-      ['--addDeploymentGroupTags', '--deploymentGroupTags \\'{{ az_devops_deployment_group_tags }}\\'']"
+    deployment_agent_cmd_args: "{{ deployment_agent_cmd_args +
+      ['--addDeploymentGroupTags', '--deploymentGroupTags', az_devops_deployment_group_tags ] }}"
   when:
-    - az_devops_deployment_group_tags is defined
+    - az_devops_deployment_group_tags is defined and az_devops_deployment_group_tags != None
 
 - name: Set proxy
   set_fact:
-    agent_cmd_args: "{{ agent_cmd_args }} + ['--proxyurl \\'{{ az_devops_proxy_url }}\\'', '--proxyusername \\'{{ az_devops_proxy_username }}\\'', '--proxypassword \\'{{ az_devops_proxy_password }}\\'']"
+    agent_cmd_args: "{{ agent_cmd_args + ['--proxyurl',  az_devops_proxy_url, '--proxyusername', az_devops_proxy_username, '--proxypassword', az_devops_proxy_password ] }}"
   when:
-    - az_devops_proxy_url is defined
+    - az_devops_proxy_url is defined and az_devops_proxy_url != None
 
-- name: Download and unarchive
+- name: Download {{ az_devops_agent_package_url }}
+  get_url:
+    url: "{{ az_devops_agent_package_url }}"
+    dest: "/tmp/az_devops_agent_package.tar.gz"
+
+- name: Unarchive /tmp/az_devops_agent_package.tar.gz
   unarchive:
-    src: "{{ az_devops_agent_package_url }}"
+    src: "/tmp/az_devops_agent_package.tar.gz"
     dest: "{{ az_devops_agent_folder }}"
     remote_src: yes
     owner: "{{ az_devops_agent_user }}"
@@ -139,9 +149,9 @@
 
 - name: Add '--replace' configuration argument
   set_fact:
-    build_agent_cmd_args: "{{ build_agent_cmd_args }} + ['--replace']"
-    deployment_agent_cmd_args: "{{ build_agent_cmd_args }} + ['--replace']"
-    resource_agent_cmd_args: "{{ resource_agent_cmd_args }} + ['--replace']"
+    build_agent_cmd_args: "{{ build_agent_cmd_args + ['--replace'] }}"
+    deployment_agent_cmd_args: "{{ build_agent_cmd_args + ['--replace'] }}"
+    resource_agent_cmd_args: "{{ resource_agent_cmd_args + ['--replace'] }}"
   when:
     - az_devops_agent_replace_existing
 

--- a/tasks/Windows.yml
+++ b/tasks/Windows.yml
@@ -7,7 +7,7 @@
   become: yes
   when:
     - az_devops_agent_create_local_user
-    
+
 - name: Ensure chocolatey is present
   win_chocolatey:
     name: chocolatey
@@ -42,49 +42,49 @@
 
 - name: Add '/Replace' configuration argument
   set_fact:
-    common_install_options: "{{ common_install_options }} + ['/Replace']"
+    common_install_options: "{{ common_install_options + ['/Replace'] }}"
   when:
     - az_devops_agent_replace_existing
 
 - name: Add deployment group tags
   set_fact:
-    deployment_install_options: "{{ deployment_install_options }} + ['/DeploymentGroupTags:{{ az_devops_deployment_group_tags }}']"
+    deployment_install_options: "{{ deployment_install_options + ['/DeploymentGroupTags:{{ az_devops_deployment_group_tags }}'] }}"
   when:
-    - az_devops_deployment_group_tags is defined
+    - az_devops_deployment_group_tags is defined and az_devops_deployment_group_tags != None
 
 - name: Add az_devops_proxy_url
   set_fact:
-    common_install_options: "{{ common_install_options }} + ['/ProxyUrl:{{ az_devops_proxy_url }}']"
+    common_install_options: "{{ common_install_options + ['/ProxyUrl:{{ az_devops_proxy_url }}'] }}"
   when:
-    - az_devops_proxy_url is defined and az_devops_proxy_url
+    - az_devops_proxy_url is defined and az_devops_proxy_url != None
 
 - name: Add az_devops_proxy_username
   set_fact:
-    common_install_options: "{{ common_install_options }} + ['/ProxyUserName:{{ az_devops_proxy_username }}']"
+    common_install_options: "{{ common_install_options + ['/ProxyUserName:{{ az_devops_proxy_username }}'] }}"
   when:
-    - az_devops_proxy_username is defined and az_devops_proxy_username
+    - az_devops_proxy_username is defined and az_devops_proxy_username != None
 
 - name: Add az_devops_proxy_password
   set_fact:
-    common_install_options: "{{ common_install_options }} + ['/ProxyPassword:{{ az_devops_proxy_password }}']"
+    common_install_options: "{{ common_install_options + ['/ProxyPassword:{{ az_devops_proxy_password }}'] }}"
   when:
-    - az_devops_proxy_password is defined and az_devops_proxy_password
+    - az_devops_proxy_password is defined and az_devops_proxy_password != None
 
 - name: Configure agent as a build server
   set_fact:
-    az_devops_agent_package_params: "{{ common_install_options }} + {{ build_agent_install_options }}"
+    az_devops_agent_package_params: "{{ common_install_options + build_agent_install_options }}"
   when:
      - az_devops_agent_role == 'build'
 
 - name: Configure agent as a deployment server
   set_fact:
-    az_devops_agent_package_params: "{{ common_install_options }} + {{ deployment_install_options }}"
+    az_devops_agent_package_params: "{{ common_install_options + deployment_install_options }}"
   when:
      - az_devops_agent_role == 'deployment'
 
 - name: Configure agent as an environment resource
   set_fact:
-    az_devops_agent_package_params: "{{ common_install_options }} + {{ resource_agent_install_options }}"
+    az_devops_agent_package_params: "{{ common_install_options + resource_agent_install_options }}"
   when:
      - az_devops_agent_role == 'resource'
 

--- a/vars/dependencies-RedHat-8.yml
+++ b/vars/dependencies-RedHat-8.yml
@@ -1,0 +1,8 @@
+az_devops_agent_dependencies:
+  - krb5-libs
+  - libicu
+  - lttng-ust
+  - openssl-libs
+  - zlib
+    # mine only found the script install libicu lttng-ust userspace-rcu
+  - userspace-rcu


### PR DESCRIPTION
- Make sure the group exists before creating user.
- Simplify the arguments builder to be sure they are list all the time and easy to read. My ansible gives error at the end complaining about adding a list to str.
- Added support for RHEL8
- Download archive first to be cached before extract. Usefull when testing roles, we do not need to download it all the time.
- Make sure we detect the value `null` with None in when condition.
  without this, we configure using option as string 'None` when running the config.sh and it failed as this is invalid option. A var with value `null` is regarded as `defined`.

This changes has been tested with RHEL8 hosts and ansible version 2.13.3