### PR TITLE
Fix conditions and list extensions for linux

### DIFF
--- a/tasks/Linux.yml
+++ b/tasks/Linux.yml
@@ -103,7 +103,7 @@
   set_fact:
     agent_cmd_args: "{{ agent_cmd_args }} + ['--proxyurl \\'{{ az_devops_proxy_url }}\\'', '--proxyusername \\'{{ az_devops_proxy_username }}\\'', '--proxypassword \\'{{ az_devops_proxy_password }}\\'']"
   when:
-    - az_devops_proxy_url is defined
+    - az_devops_proxy_url is not none
 
 - name: Download and unarchive
   unarchive:

--- a/tasks/Linux.yml
+++ b/tasks/Linux.yml
@@ -97,7 +97,7 @@
     deployment_agent_cmd_args: "{{ deployment_agent_cmd_args }} +
       ['--addDeploymentGroupTags', '--deploymentGroupTags \\'{{ az_devops_deployment_group_tags }}\\'']"
   when:
-    - az_devops_deployment_group_tags is defined
+    - az_devops_deployment_group_tags is not none
 
 - name: Set proxy
   set_fact:

--- a/tasks/Linux.yml
+++ b/tasks/Linux.yml
@@ -94,14 +94,13 @@
 
 - name: Add deployment group tags
   set_fact:
-    deployment_agent_cmd_args: "{{ deployment_agent_cmd_args }} +
-      ['--addDeploymentGroupTags', '--deploymentGroupTags \\'{{ az_devops_deployment_group_tags }}\\'']"
+    deployment_agent_cmd_args: "{{ deployment_agent_cmd_args + ['--addDeploymentGroupTags', '--deploymentGroupTags' , az_devops_deployment_group_tags ] }}"
   when:
     - az_devops_deployment_group_tags is not none
 
 - name: Set proxy
   set_fact:
-    agent_cmd_args: "{{ agent_cmd_args }} + ['--proxyurl \\'{{ az_devops_proxy_url }}\\'', '--proxyusername \\'{{ az_devops_proxy_username }}\\'', '--proxypassword \\'{{ az_devops_proxy_password }}\\'']"
+    agent_cmd_args: "{{ agent_cmd_args + ['--proxyurl' , az_devops_proxy_url, '--proxyusername' , az_devops_proxy_username, '--proxypassword', az_devops_proxy_password ] }}"
   when:
     - az_devops_proxy_url is not none
 
@@ -139,9 +138,9 @@
 
 - name: Add '--replace' configuration argument
   set_fact:
-    build_agent_cmd_args: "{{ build_agent_cmd_args }} + ['--replace']"
-    deployment_agent_cmd_args: "{{ build_agent_cmd_args }} + ['--replace']"
-    resource_agent_cmd_args: "{{ resource_agent_cmd_args }} + ['--replace']"
+    build_agent_cmd_args: "{{ build_agent_cmd_args + ['--replace'] }}"
+    deployment_agent_cmd_args: "{{ build_agent_cmd_args + ['--replace'] }}"
+    resource_agent_cmd_args: "{{ resource_agent_cmd_args + ['--replace'] }}"
   when:
     - az_devops_agent_replace_existing
 

--- a/vars/dependencies-Ubuntu-22.yml
+++ b/vars/dependencies-Ubuntu-22.yml
@@ -1,0 +1,6 @@
+az_devops_agent_dependencies:
+  - libcurl4
+  - libgssapi-krb5-2
+  - libicu66
+  - libssl1.1
+  - acl

--- a/vars/dependencies-Ubuntu-22.yml
+++ b/vars/dependencies-Ubuntu-22.yml
@@ -1,6 +1,6 @@
 az_devops_agent_dependencies:
   - libcurl4
   - libgssapi-krb5-2
-  - libicu66
+  - libicu70
   - libssl1.1
   - acl


### PR DESCRIPTION
Relates to #67 #66

Since default values for `az_devops_proxy_url` and `az_devops_deployment_group_tags` had been defined even tough they were `null` the `... is defined` condtions were always true.
Therefore I updated the condition check as mentioned in the issues

Also the using `+` to combine two lists must happen inside on expression, therefore this ways adjusted too