### PR TITLE
fix(Windows): formatting package_params input to Chocolatey

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,8 +29,9 @@ Available variables are listed below, along with default values (see `defaults/m
     az_devops_agent_pool_name: "Default"
     az_devops_agent_role: "build"
     az_devops_deployment_group_tags: null
-    az_devops_environment_name: null
     az_devops_deployment_group_name: null
+    az_devops_environment_name: null
+    az_devops_environment_tags: null
     az_devops_agent_replace_existing: false
     az_devops_reconfigure_agent: false
     az_devops_agent_user_capabilities: null
@@ -104,6 +105,10 @@ Available variables are listed below, along with default values (see `defaults/m
 - **az_devops_environment_name**
 
   Use in conjuction with the `resource` agent role. The name of the environment in which to add the VM resource.  **This needs to be manually created in you Azure DevOps project beforehand.**
+
+- **az_devops_environment_tags**
+
+  Use in conjuction with the `resource` agent role. Allows the user of tags to identify the agent (ex: QA, Staging, Prod, etc.)
 
 - **az_devops_agent_replace_existing**
 

--- a/tasks/Windows.yml
+++ b/tasks/Windows.yml
@@ -51,42 +51,46 @@
     deployment_install_options: "{{ deployment_install_options + ['/DeploymentGroupTags:' + az_devops_deployment_group_tags] }}"
   when:
     - az_devops_deployment_group_tags is defined
+    - az_devops_deployment_group_tags
 
 - name: Add az_devops_proxy_url
   ansible.builtin.set_fact:
     common_install_options: "{{ common_install_options + ['/ProxyUrl:' + az_devops_proxy_url] }}"
   when:
-    - az_devops_proxy_url is defined and az_devops_proxy_url
+    - az_devops_proxy_url is defined
+    - az_devops_proxy_url
 
 - name: Add az_devops_proxy_username
   ansible.builtin.set_fact:
     common_install_options: "{{ common_install_options + ['/ProxyUserName:' + az_devops_proxy_username] }}"
   when:
-    - az_devops_proxy_username is defined and az_devops_proxy_username
+    - az_devops_proxy_username is defined 
+    - az_devops_proxy_username
 
 - name: Add az_devops_proxy_password
   ansible.builtin.set_fact:
     common_install_options: "{{ common_install_options + ['/ProxyPassword:' + az_devops_proxy_password] }}"
   when:
-    - az_devops_proxy_password is defined and az_devops_proxy_password
+    - az_devops_proxy_password is defined 
+    - az_devops_proxy_password
 
 - name: Configure agent as a build server
   ansible.builtin.set_fact:
     az_devops_agent_package_params: "{{ common_install_options + build_agent_install_options }}"
   when:
-     - az_devops_agent_role == 'build'
+    - az_devops_agent_role == 'build'
 
 - name: Configure agent as a deployment server
   ansible.builtin.set_fact:
     az_devops_agent_package_params: "{{ common_install_options + deployment_install_options }}"
   when:
-     - az_devops_agent_role == 'deployment'
+    - az_devops_agent_role == 'deployment'
 
 - name: Configure agent as an environment resource
   ansible.builtin.set_fact:
     az_devops_agent_package_params: "{{ common_install_options + resource_agent_install_options }}"
   when:
-     - az_devops_agent_role == 'resource'
+    - az_devops_agent_role == 'resource'
 
 - name: Install azure-pipelines-agent package
   chocolatey.chocolatey.win_chocolatey:

--- a/tasks/Windows.yml
+++ b/tasks/Windows.yml
@@ -4,10 +4,10 @@
     password: "{{ az_devops_agent_password }}"
     state: present
     password_never_expires: true
-  become: yes
+  become: true
   when:
+
     - az_devops_agent_create_local_user
-    
 - name: Ensure chocolatey is present
   win_chocolatey:
     name: chocolatey
@@ -17,7 +17,7 @@
 # https://github.com/flcdrg/au-packages/blob/master/azure-pipelines-agent/README.md
 
 - name: Set basic agent package parameters
-  set_fact:
+  ansible.builtin.set_fact:
     common_install_options:
       - "/Directory:{{ az_devops_agent_folder }}"
       - "/Url:{{ az_devops_server_url }}"
@@ -41,55 +41,55 @@
       - "/ProjectName:{{ az_devops_project_name }}"
 
 - name: Add '/Replace' configuration argument
-  set_fact:
-    common_install_options: "{{ common_install_options }} + ['/Replace']"
+  ansible.builtin.set_fact:
+    common_install_options: "{{ common_install_options + ['/Replace'] }}"
   when:
     - az_devops_agent_replace_existing
 
 - name: Add deployment group tags
-  set_fact:
-    deployment_install_options: "{{ deployment_install_options }} + ['/DeploymentGroupTags:{{ az_devops_deployment_group_tags }}']"
+  ansible.builtin.set_fact:
+    deployment_install_options: "{{ deployment_install_options + ['/DeploymentGroupTags:' + az_devops_deployment_group_tags] }}"
   when:
     - az_devops_deployment_group_tags is defined
 
 - name: Add az_devops_proxy_url
-  set_fact:
-    common_install_options: "{{ common_install_options }} + ['/ProxyUrl:{{ az_devops_proxy_url }}']"
+  ansible.builtin.set_fact:
+    common_install_options: "{{ common_install_options + ['/ProxyUrl:' + az_devops_proxy_url] }}"
   when:
     - az_devops_proxy_url is defined and az_devops_proxy_url
 
 - name: Add az_devops_proxy_username
-  set_fact:
-    common_install_options: "{{ common_install_options }} + ['/ProxyUserName:{{ az_devops_proxy_username }}']"
+  ansible.builtin.set_fact:
+    common_install_options: "{{ common_install_options + ['/ProxyUserName:' + az_devops_proxy_username] }}"
   when:
     - az_devops_proxy_username is defined and az_devops_proxy_username
 
 - name: Add az_devops_proxy_password
-  set_fact:
-    common_install_options: "{{ common_install_options }} + ['/ProxyPassword:{{ az_devops_proxy_password }}']"
+  ansible.builtin.set_fact:
+    common_install_options: "{{ common_install_options + ['/ProxyPassword:' + az_devops_proxy_password] }}"
   when:
     - az_devops_proxy_password is defined and az_devops_proxy_password
 
 - name: Configure agent as a build server
-  set_fact:
-    az_devops_agent_package_params: "{{ common_install_options }} + {{ build_agent_install_options }}"
+  ansible.builtin.set_fact:
+    az_devops_agent_package_params: "{{ common_install_options + build_agent_install_options }}"
   when:
      - az_devops_agent_role == 'build'
 
 - name: Configure agent as a deployment server
-  set_fact:
-    az_devops_agent_package_params: "{{ common_install_options }} + {{ deployment_install_options }}"
+  ansible.builtin.set_fact:
+    az_devops_agent_package_params: "{{ common_install_options + deployment_install_options }}"
   when:
      - az_devops_agent_role == 'deployment'
 
 - name: Configure agent as an environment resource
-  set_fact:
-    az_devops_agent_package_params: "{{ common_install_options }} + {{ resource_agent_install_options }}"
+  ansible.builtin.set_fact:
+    az_devops_agent_package_params: "{{ common_install_options + resource_agent_install_options }}"
   when:
      - az_devops_agent_role == 'resource'
 
 - name: Install azure-pipelines-agent package
-  win_chocolatey:
+  chocolatey.chocolatey.win_chocolatey:
     name: azure-pipelines-agent
     state: present
     version: "{{ az_devops_agent_version }}"

--- a/tasks/Windows.yml
+++ b/tasks/Windows.yml
@@ -53,6 +53,13 @@
     - az_devops_deployment_group_tags is defined
     - az_devops_deployment_group_tags
 
+- name: Add environment resource tags
+  ansible.builtin.set_fact:
+    resource_agent_install_options: "{{ resource_agent_install_options + ['/EnvironmentTags:' + az_devops_environment_tags] }}"
+  when:
+    - az_devops_environment_tags is defined
+    - az_devops_environment_tags
+
 - name: Add az_devops_proxy_url
   ansible.builtin.set_fact:
     common_install_options: "{{ common_install_options + ['/ProxyUrl:' + az_devops_proxy_url] }}"


### PR DESCRIPTION
fix(Windows): formatting package_params input to Chocolatey so they are treated like a list instead of a string. The package_params were effectively being ignored because of this.

Correcting Ansible lint warnings: FQCN + use of 'true' instead of 'yes'

This will resolve #74 