### PR TITLE
fix set proxy condition

### DIFF
--- a/tasks/Linux.yml
+++ b/tasks/Linux.yml
@@ -103,7 +103,7 @@
   set_fact:
     agent_cmd_args: "{{ agent_cmd_args }} + ['--proxyurl \\'{{ az_devops_proxy_url }}\\'', '--proxyusername \\'{{ az_devops_proxy_username }}\\'', '--proxypassword \\'{{ az_devops_proxy_password }}\\'']"
   when:
-    - az_devops_proxy_url is defined
+    - az_devops_proxy_url is defined and az_devops_proxy_url
 
 - name: Download and unarchive
   unarchive:


### PR DESCRIPTION
On Ansible 2.14.17, this task was firing without having set `az_devops_proxy_url` (so it was still defaulted to `null`). It seems that a variable set to `null` is still defined.

I believe my change makes sure it's defined _and_ has a non-null value. In any case, it does properly skip that task.