### PR TITLE
Feature/fix combined jinja rhel update

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ Available variables are listed below, along with default values (see `defaults/m
     az_devops_accountname: null
     az_devops_accesstoken: null
     az_devops_project_name: null
-    az_devops_agent_version: 2.188.3
+    az_devops_agent_version: 3.241.0
     az_devops_agent_user: "az_devops_agent"
     az_devops_agent_uid: null
     az_devops_agent_name: "{{ ansible_hostname }}"
@@ -56,6 +56,21 @@ Available variables are listed below, along with default values (see `defaults/m
 - **az_devops_agent_version**
 
   Version of the installed agent package. Should be periodically updated to the latest version (see [here](https://github.com/microsoft/azure-pipelines-agent/releases/latest)).
+
+- **az_devops_agent_package_url**
+
+  URL for the agent package (see [here](https://github.com/microsoft/azure-pipelines-agent/releases) for a list of available versions).
+  The value is pre-generated but can be controlled by setting `az_devops_agent_package_url` in your Ansible (inventory) file as follows:
+  - For pipeline based package with modern Node support for Azure DevOps SaaS:
+  ```yaml
+  az_devops_agent_package_url: "https://vstsagentpackage.azureedge.net/agent/{{ az_devops_agent_version }}/pipelines-agent-{{ ansible_system | lower | replace('darwin', 'osx') }}-{{ ansible_architecture | replace('x86_64', 'x64') | replace('aarch64', 'arm64') }}-{{ az_devops_agent_version }}.tar.gz"
+  ```
+  
+  - For pipeline based package without modern Node support for VSTS / Azure DevOps Server: you can leave as it is but it won't support arm based infra, otherwise use as follows:
+  ```yaml
+  az_devops_agent_package_url: "https://vstsagentpackage.azureedge.net/agent/{{ az_devops_agent_version }}/vsts-agent-{{ ansible_system | lower | replace('darwin', 'osx') }}-{{ ansible_architecture | replace('x86_64', 'x64') | replace('aarch64', 'arm64') }}-{{ az_devops_agent_version }}.tar.gz"
+  ```
+  It can be added as a default variable that is used across all environments, I will leave for someone else to add it, as it is an easy implementation and not a priority.
 
 - **az_devops_agent_user**
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,4 +1,4 @@
-az_devops_agent_version: 2.188.3
+az_devops_agent_version: 3.241.0
 az_devops_agent_user: "az_devops_agent"
 az_devops_agent_name: "{{ ansible_hostname }}"
 az_devops_server_url: "https://dev.azure.com/{{ az_devops_accountname }}/"

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,6 +17,8 @@ galaxy_info:
     - name: EL
       versions:
         - 7
+        - 8
+        - 9
     - name: Debian
       versions:
         - stretch
@@ -28,6 +30,13 @@ galaxy_info:
     - name: MacOSX
       versions:
         - 10.15
+        - 13.6.0
+        - 13.6.6
+        - 14.3
+        - 14.3.1
+        - 14.4
+        - 14.4.1
+        - 14.5
 
   galaxy_tags:
     - azure

--- a/tasks/Linux.yml
+++ b/tasks/Linux.yml
@@ -66,12 +66,12 @@
     agent_cmd_args:
       - "./config.sh"
       - "--unattended"
-      - "--acceptteeeula"
+      - "--acceptTeeEula"
       - "--url '{{ az_devops_server_url }}'"
       - "--work '{{ az_devops_work_folder }}'"
-      - "--auth PAT"
+      - "--auth pat"
       - "--token '{{ az_devops_accesstoken }}'"
-      - "--runasservice"
+      - "--runasservice" # * Windows Only
     build_agent_cmd_args:
       - "--pool '{{ az_devops_agent_pool_name }}'"
       - "--agent '{{ az_devops_agent_name }}'"
@@ -87,6 +87,13 @@
     service_is_installed: "{{ svc_status.stdout is defined and svc_status.stdout is not regex('not installed') }}"
     service_is_running: "{{ svc_status.stdout is defined and svc_status.stdout is regex('active \\(running\\)') }}"
     is_requested_version: "{{ bin_agent_listener.stat.exists and agent_listener_version.stdout is defined and agent_listener_version.stdout == az_devops_agent_version }}"
+
+
+- name: Set Agent config facts combined
+  set_fact:
+    build_server_cmd_args: "{{ agent_cmd_args + build_agent_cmd_args }}"
+    deployment_server_cmd_args: "{{ agent_cmd_args + deployment_agent_cmd_args }}"
+    resource_server_cmd_args: "{{ agent_cmd_args + resource_agent_cmd_args }}"
 
 - name: Determine if the agent should be reconfigured or replaced
   set_fact:
@@ -139,14 +146,14 @@
 
 - name: Add '--replace' configuration argument
   set_fact:
-    build_agent_cmd_args: "{{ build_agent_cmd_args }} + ['--replace']"
-    deployment_agent_cmd_args: "{{ build_agent_cmd_args }} + ['--replace']"
-    resource_agent_cmd_args: "{{ resource_agent_cmd_args }} + ['--replace']"
+    build_server_cmd_args: "{{ build_server_cmd_args }} + ['--replace']"
+    deployment_server_cmd_args: "{{ deployment_server_cmd_args }} + ['--replace']"
+    resource_server_cmd_args: "{{ resource_server_cmd_args }} + ['--replace']"
   when:
     - az_devops_agent_replace_existing
 
 - name: Configure agent as a build server
-  command: "{{ (agent_cmd_args + build_agent_cmd_args) | join(' ') }}"
+  command: "{{ build_server_cmd_args | join(' ') }}"
   args:
     chdir: "{{ az_devops_agent_folder }}"
     creates: "{{ az_devops_agent_folder }}/.agent"
@@ -157,7 +164,7 @@
     - (not service_is_installed) or reconfigure_or_replace
 
 - name: Configure agent as a deployment server
-  command: "{{ (agent_cmd_args + deployment_agent_cmd_args) | join(' ') }}"
+  command: "{{ deployment_server_cmd_args | join(' ') }}"
   args:
     chdir: "{{ az_devops_agent_folder }}"
     creates: "{{ az_devops_agent_folder }}/.agent"
@@ -168,7 +175,7 @@
     - (not service_is_installed) or reconfigure_or_replace
 
 - name: Configure agent as an environment resource
-  command: "{{ (agent_cmd_args + resource_agent_cmd_args) | join(' ') }}"
+  command: "{{ resource_server_cmd_args | join(' ') }}"
   args:
     chdir: "{{ az_devops_agent_folder }}"
     creates: "{{ az_devops_agent_folder }}/.agent"

--- a/tasks/Linux.yml
+++ b/tasks/Linux.yml
@@ -10,13 +10,15 @@
 - name: Create directories
   file:
     state: directory
-    path: "{{ item }}"
+    path: "{{ directory }}"
     owner: "{{ az_devops_agent_user }}"
     group: "{{ az_devops_agent_group }}"
     mode: 0755
   loop:
     - "{{ az_devops_agent_folder }}"
     - "{{ az_devops_work_folder }}"
+  loop_control:
+    loop_var: directory
   become: true
 
 - name: Install dependencies
@@ -87,7 +89,6 @@
     service_is_installed: "{{ svc_status.stdout is defined and svc_status.stdout is not regex('not installed') }}"
     service_is_running: "{{ svc_status.stdout is defined and svc_status.stdout is regex('active \\(running\\)') }}"
     is_requested_version: "{{ bin_agent_listener.stat.exists and agent_listener_version.stdout is defined and agent_listener_version.stdout == az_devops_agent_version }}"
-
 
 - name: Set Agent config facts combined
   set_fact:
@@ -189,14 +190,20 @@
   community.general.ini_file:
     path: "{{ az_devops_agent_folder }}/.env"
     section: null
-    option: "{{ item.key }}"
-    value: "{{ item.value }}"
+    option: "{{ capability.key }}"
+    value: "{{ capability.value }}"
     no_extra_spaces: yes
     owner: "{{ az_devops_agent_user }}"
     group: "{{ az_devops_agent_group }}"
   loop: "{{ az_devops_agent_user_capabilities | default({}) | dict2items }}"
+  loop_control:
+    loop_var: capability
   become: true
 
+- name: Print Debug
+  debug:
+    msg: "{{ az_devops_agent_user_capabilities | default({}) | dict2items }}"
+    
 - name: Install agent service
   command: ./svc.sh install {{ az_devops_agent_user }}
   become: true

--- a/tasks/Linux.yml
+++ b/tasks/Linux.yml
@@ -147,9 +147,9 @@
 
 - name: Add '--replace' configuration argument
   set_fact:
-    build_server_cmd_args: "{{ build_server_cmd_args }} + ['--replace']"
-    deployment_server_cmd_args: "{{ deployment_server_cmd_args }} + ['--replace']"
-    resource_server_cmd_args: "{{ resource_server_cmd_args }} + ['--replace']"
+    build_server_cmd_args: "{{ build_server_cmd_args + ['--replace'] }}"
+    deployment_server_cmd_args: "{{ deployment_server_cmd_args + ['--replace'] }}"
+    resource_server_cmd_args: "{{ resource_server_cmd_args + ['--replace'] }}"
   when:
     - az_devops_agent_replace_existing
 

--- a/tasks/Linux.yml
+++ b/tasks/Linux.yml
@@ -200,10 +200,6 @@
     loop_var: capability
   become: true
 
-- name: Print Debug
-  debug:
-    msg: "{{ az_devops_agent_user_capabilities | default({}) | dict2items }}"
-    
 - name: Install agent service
   command: ./svc.sh install {{ az_devops_agent_user }}
   become: true

--- a/vars/dependencies-Linux.yml
+++ b/vars/dependencies-Linux.yml
@@ -1,0 +1,3 @@
+# Add empty dependency, refer to ./bin/install_dependencies.sh for more info
+---
+az_devops_agent_dependencies: []

--- a/vars/dependencies-RedHat-8.yml
+++ b/vars/dependencies-RedHat-8.yml
@@ -1,0 +1,6 @@
+az_devops_agent_dependencies:
+  - krb5-libs
+  - libicu
+  - lttng-ust
+  - openssl-libs
+  - zlib

--- a/vars/dependencies-RedHat-9.yml
+++ b/vars/dependencies-RedHat-9.yml
@@ -1,0 +1,6 @@
+az_devops_agent_dependencies:
+  - krb5-libs
+  - libicu
+  - lttng-ust
+  - openssl-libs
+  - zlib


### PR DESCRIPTION
jinja3 - add combined set facts and fix the use of join with combined vars for configure agent - there might be other methods in jinja3, but a simple fix does this job
add RHEL dependencies for 8 and 9, and empty for Linux with notes
Readme update with package url
fix loops to use loop_controls and loop_vars for create dir and capabilities task

I have executed the code in my VM with AlmaLinux 9.4 aarch64, the readme includes the package url structure in details for others to use the package successfully.  fixed all the warnings and errors.
```
PLAY RECAP ********************************************************************************************************************************************************************************************************************************************
lxbuild-server-01          : ok=81   changed=5    unreachable=0    failed=0    skipped=36   rescued=0    ignored=0   
```